### PR TITLE
Feature/multimodal-similarity-search messages

### DIFF
--- a/srv/GetKey.srv
+++ b/srv/GetKey.srv
@@ -1,5 +1,6 @@
 string query
 float64 threshold
+float64 max_size
 ---
 string key
 bool success

--- a/srv/GetKey.srv
+++ b/srv/GetKey.srv
@@ -1,3 +1,5 @@
 string query
+float64 threshold
 ---
 string key
+bool success


### PR DESCRIPTION
This pull request add some backward compatible updates to the `GetKey` service definition, required for the `multimodal-smimilarity-search` branch of `butia_world`. GetKey requests now have optional parameters `similaity_threshold` and `max_size` used to further filter detections lifted to 3d on the map.